### PR TITLE
存在しないウェブページへリンクしちゃっているのを直す

### DIFF
--- a/mobile-training/README.md
+++ b/mobile-training/README.md
@@ -1,6 +1,6 @@
 # モバイルアプリ(Flutter) 研修
 
-* [テキスト](https://pepabo.github.io/mobile-training/)
+* [テキスト](https://github.com/pepabo/training/tree/master/mobile-training/docs)
 * [教材](./app_start/)
 * [完成品](./app_goal/)
 


### PR DESCRIPTION
ぼくは https://pepabo.github.io/mobile-training/ の出自を把握していないのだけれど、とにかく今は存在していないので、少なくともアクセスできる https://github.com/pepabo/training/tree/master/mobile-training/docs の方がマシと思うのでそうします！

Resolve https://github.com/pepabo/training/issues/9