### PR TITLE
[Frontend研修] 2024年現在のNode.js LTSである20.xに対応します

### DIFF
--- a/frontend-training/app_goal/package.json
+++ b/frontend-training/app_goal/package.json
@@ -34,7 +34,7 @@
     "babel-loader": "8.2.2",
     "babel-plugin-macros": "3.1.0",
     "typescript": "^4.3.4",
-    "webpack": "5.38.1",
+    "webpack": "5.91.0",
     "webpack-cli": "4.7.2",
     "webpack-dev-server": "^3.11.2",
     "webpack-manifest-plugin": "3.1.1"

--- a/frontend-training/docs/ch16/README.md
+++ b/frontend-training/docs/ch16/README.md
@@ -27,7 +27,8 @@ Homebrew で直接インストールもできますが、 Node.js は頻繁に�
 
 （私見です： nodenv + node-build の方が rbenv + ruby-build と同じようなコマンドになっているので使いやすいと思います）
 
-2021年6月現在では Node.js 14 を指定すると良いでしょう。nodenv であれば `sample_app` ディレクトリ直下で `nodenv local 14.17.0` のようなコマンドを実行しましょう。
+[Node.js Releases](https://nodejs.org/en/about/previous-releases) でLTS(長期サポート)のバージョンを確認できます。
+2024年6月現在では Node.js 20.x を指定すると良いでしょう。nodenv であれば `sample_app` ディレクトリ直下で `nodenv local 20.13.1` のようなコマンドを実行しましょう。
 
 ```js
 // hello_nodejs.js

--- a/frontend-training/docs/ch17/README.md
+++ b/frontend-training/docs/ch17/README.md
@@ -43,7 +43,7 @@ npm uninstall @rails/webpacker
 さて、Rails Tutorial を終えた時点では `webpack` と `webpack-cli` が `dependencies` 内に宣言されていますが、webpack はモジュールバンドリングのためだけに必要なものでありアプリケーション実行時には必要ないので、本来 `devDependencies` にあるべきものです。そこで以下のコマンドを実行しましょう:
 
 ```bash
-npm install --save-dev --save-exact webpack@5.38.1 webpack-cli@4.7.2
+npm install --save-dev --save-exact webpack@5.91.0 webpack-cli@4.7.2
 ```
 
 `--save-dev` は `Gemfile` の `group :development, :test` のようなもので、開発時とテストの時のみ使うもの（`devDependencies` に追加したいもの）につけるオプションです。


### PR DESCRIPTION
最新のLTS版を参照するようにします。また、この変更で必要になった一部依存パッケージのバージョンの更新もしています。